### PR TITLE
Don't use ignore-platform-reqs when installing mongo-php-adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,21 +31,21 @@ before_script:
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then extension="mongo"; echo "yes" | pecl install mongo; else extension="mongodb"; (pecl install mongodb || true); fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then phpversion=$(php --version | grep "PHP 7.1" | cut -f2 -d' '); (echo "extension=mongodb.so" > /home/travis/.phpenv/versions/$phpversion/etc/conf.d/mongodb.ini); fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then phpversion=$(php --version | grep "PHP 7.2" | cut -f2 -d' '); (echo "extension=mongodb.so" > /home/travis/.phpenv/versions/$phpversion/etc/conf.d/mongodb.ini); fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer require "alcaeus/mongo-php-adapter" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/cache:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/framework-bundle:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/stopwatch:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/process:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/options-resolver:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/finder:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/filesystem:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/routing:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/debug:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/event-dispatcher:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/http-foundation:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/http-kernel:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/dependency-injection:3.4.0" --ignore-platform-reqs; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/config:3.4.0" --ignore-platform-reqs; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer config "platform.ext-mongo" "1.6.16" && composer require alcaeus/mongo-php-adapter; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/cache:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/framework-bundle:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/stopwatch:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/process:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/options-resolver:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/finder:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/filesystem:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/routing:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/debug:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/event-dispatcher:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/http-foundation:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/http-kernel:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/dependency-injection:3.4.0"; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer require "symfony/config:3.4.0"; fi
   - composer install
 
 script:


### PR DESCRIPTION
Using `ignore-platform-reqs` can cause a bunch of errors down the line (e.g. by installing incompatible package versions not suited for the current PHP version). Thus, `ext-mongodb` is provided via `config.platform`.