### PR TITLE
Fix documentation

### DIFF
--- a/Resources/doc/symfony2-3.md
+++ b/Resources/doc/symfony2-3.md
@@ -36,7 +36,8 @@ ORM Setup:
 __app/config/config.yml:__
 ```yaml
 dtc_queue:
-    default_manager: orm
+    manager:
+       job: orm
 ```
 
 __NOTE:__ You may need to add DtcQueueBundle to your mappings section in config.yml if auto_mapping is not enabled


### PR DESCRIPTION
Using 

```yaml
dtc_queue:
    default_manager: orm
```

triggers an error in Symfony 2.8 (You have requested a synthetic service ("dtc_queue.document_manager"). The DIC does not know how to construct this service). 

Reading the documentation in the main README.md, shouldn't the configuration state

```yaml
dtc_queue:
    manager:
       job: orm
```

With this, the `/dtc_queue/*` routes work.