### PR TITLE
missing setName call for Command

### DIFF
--- a/Command/CreateJobCommand.php
+++ b/Command/CreateJobCommand.php
@@ -53,6 +53,7 @@ class CreateJobCommand extends ContainerAwareCommand
             )
             ->setDescription('Create a job - for expert users')
             ->setHelp($this->getHelpMessage())
+            ->setName(self::$defaultName)
         ;
     }
 


### PR DESCRIPTION
Causes logicexception:

  [Symfony\Component\Console\Exception\LogicException]                                          
  The command defined in "Dtc\QueueBundle\Command\CreateJobCommand" cannot have an empty name.