### PR TITLE
Use base url for assets

### DIFF
--- a/Resources/views/Queue/jobs.html.twig
+++ b/Resources/views/Queue/jobs.html.twig
@@ -7,5 +7,5 @@
     <h3>Waiting Jobs</h3>
     {{ dtc_grid.render | raw }}
     {{ queue_macros.worker_method_button('Archive', 'dtc_queue_archive', worker_methods, prompt_message, 'archive') }}
-    <script src="/bundles/dtcqueue/js/jobs.js?v=5"></script>
+    <script src="{{ app.request.baseUrl }}/bundles/dtcqueue/js/jobs.js?v=5"></script>
 {% endblock %}

--- a/Resources/views/Queue/jobs_running.html.twig
+++ b/Resources/views/Queue/jobs_running.html.twig
@@ -9,5 +9,5 @@
     {{ dtc_grid.render | raw }}
     {{ queue_macros.worker_method_button('Prune Stalled', 'dtc_queue_prune_stalled', worker_methods, prompt_message, 'prunestalled') }}
     {{ queue_macros.worker_method_button('Reset Stalled', 'dtc_queue_reset_stalled', worker_methods, prompt_message, 'resetstalled') }}
-    <script src="/bundles/dtcqueue/js/jobs.js?v=5"></script>
+    <script src="{{ app.request.baseUrl }}/bundles/dtcqueue/js/jobs.js?v=5"></script>
 {% endblock %}

--- a/Resources/views/Queue/trends.html.twig
+++ b/Resources/views/Queue/trends.html.twig
@@ -65,6 +65,6 @@ dtc_queue:
           var states = {{ states | json_encode | raw }};
           var fetchPath = '{{ path('dtc_queue_timings') }}';
         </script>
-        <script src="/bundles/dtcqueue/js/trends.js?v=1"></script>
+        <script src="{{ app.request.baseUrl }}/bundles/dtcqueue/js/trends.js?v=1"></script>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Include base url for javascript & CSS assets in twig templates.