### PR TITLE
Updated the Symfony 4 documentation as the default_manager option is deprecated

### DIFF
--- a/Resources/doc/symfony4.md
+++ b/Resources/doc/symfony4.md
@@ -48,8 +48,10 @@ doctrine_mongodb:
 __config/packages/dtc_queue.yaml:__
 ```yaml
 dtc_queue:
-    default_manager: orm
-    # ...
+    manager:
+        # This parameter is required and should typically be set to one of:
+        #   [odm|orm|beanstalkd|rabbit_mq|redis]
+        job: orm
 ```
 
 See the full list of options in [/Resources/doc/full-configuration.md](/Resources/doc/full-configuration.md)


### PR DESCRIPTION
Hi,

The documentation for Symfony 4 says to set the `default_manager` option in config/packages/dtc_queue.yaml, however this option is deprecated.

This PR updates the documentation with the correct option.

Cheers

Tom