### PR TITLE
Fix Symfony 5.1 deprecation warning: NodeDefinition::setDeprecated() …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 6.1.1
+   * Fix issue #129 with pheanstalk.
 ### 6.1.0
    * Fix issue #129 with pheanstalk.
 ### 6.0.10

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -68,8 +68,10 @@ class Configuration implements ConfigurationInterface
     {
         $node = $node->$type($name);
 
-        if (Kernel::VERSION_ID >= 30400) {
-            $node = $node->setDeprecated('mmucklo/queue-bundle', '5.1',$deprecatedMessage);
+        if (Kernel::VERSION_ID >= 51000) { 
+            $node = $node->setDeprecated('mmucklo/queue-bundle', '5.1', $deprecatedMessage);
+        }else{
+            $node = $node->setDeprecated($deprecatedMessage);
         }
 
         return $node->end();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -69,7 +69,7 @@ class Configuration implements ConfigurationInterface
         $node = $node->$type($name);
 
         if (Kernel::VERSION_ID >= 30400) {
-            $node = $node->setDeprecated($deprecatedMessage);
+            $node = $node->setDeprecated('mmucklo/queue-bundle', '5.1',$deprecatedMessage);
         }
 
         return $node->end();


### PR DESCRIPTION
A fix for Symfony 5.1 deprecation warnings. 

```
Since symfony/config 5.1: The signature of method "Symfony\Component\Config\Definition\Builder\NodeDefinition::setDeprecated()" requires 3 arguments: "string $package, string $version, string $message", not defining them is deprecated.
Hide context    Show trace
[▼
  "exception" => Symfony\Component\ErrorHandler\Exception\SilencedErrorContext {#1660 ▼
    +count: 28
    -severity: E_USER_DEPRECATED
    trace: {▼
      D:\Projects\espos\espos1\vendor\symfony\config\Definition\Builder\NodeDefinition.php:176 {▶}
      D:\Projects\espos\espos1\vendor\mmucklo\queue-bundle\DependencyInjection\Configuration.php:72 {▼
        › if (Kernel::VERSION_ID >= 30400) {
        ›     $node = $node->setDeprecated($deprecatedMessage);
        › }
      }
    }
  }
]
```

![Screenshot_69](https://user-images.githubusercontent.com/944350/89209081-e70ac780-d5bd-11ea-8e74-24538ef90952.png)
