### PR TITLE
Deprecation fix for 5.1. Wrong Kernel::VERSION_ID specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 6.2.1
+   * Deprecation fix for 5.1.
 ### 6.2.0
    * Deprecation fix for 5.1.
    * Fix build, update mongo getJob a bit.

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -68,7 +68,7 @@ class Configuration implements ConfigurationInterface
     {
         $node = $node->$type($name);
 
-        if (Kernel::VERSION_ID >= 51000) {
+        if (Kernel::VERSION_ID >= 50100) {
             $node = $node->setDeprecated('mmucklo/queue-bundle', '5.1', $deprecatedMessage);
         } elseif (Kernel::VERSION_ID >= 30400) {
             $node = $node->setDeprecated($deprecatedMessage);


### PR DESCRIPTION
With #131 we commited changes for this fix, but it's the wrong Kernel::VERSION_ID. I've fixed it.
 Please check.

![Screenshot_71](https://user-images.githubusercontent.com/944350/89862452-48c3c680-dba8-11ea-92ce-dca543740081.png)
