### PR TITLE
Return value of "Dtc\QueueBundle\Command\RunCommand::execute()" must be of the type int, "null" returned.

### DIFF
--- a/Run/Loop.php
+++ b/Run/Loop.php
@@ -99,7 +99,7 @@ class Loop
             $this->log('error', "Job id is not found: {$jobId}");
             $this->runManager->runStop($run, $start);
 
-            return;
+            return 0;
         }
 
         $job = $this->workerManager->runJob($job);
@@ -108,7 +108,7 @@ class Loop
         $this->runManager->runStop($run, $start);
         $this->log('info', 'Ended with 1 job processed over '.strval($run->getElapsed()).' seconds.');
 
-        return;
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Error when executing:

```php bin/console dtc:queue:run --id=10```

In Symfony 5 you get:
```
Return value of "Dtc\QueueBundle\Command\RunCommand::execute()" must be of the type int, "null" returned.
```
![Screenshot_14](https://user-images.githubusercontent.com/944350/102695633-e307db00-4228-11eb-98ae-ffc093a57c29.png)
