### PR TITLE
Fixes use of AlsoLoad annotation

### DIFF
--- a/Document/BaseJob.php
+++ b/Document/BaseJob.php
@@ -56,7 +56,7 @@ abstract class BaseJob extends StallableJob
 
     /**
      * @ODM\Field(type="date", nullable=true)
-     * @ODM\AlsoLoad(name="when")
+     * @ODM\AlsoLoad("when")
      * @ODM\Index(unique=false, order="asc")
      */
     protected $whenAt;
@@ -111,13 +111,13 @@ abstract class BaseJob extends StallableJob
     protected $runId;
 
     /**
-     * @ODM\AlsoLoad(name="stalledCount")
+     * @ODM\AlsoLoad("stalledCount")
      * @ODM\Field(type="int")
      */
     protected $stalls = 0;
 
     /**
-     * @ODM\AlsoLoad(name="maxStalled")
+     * @ODM\AlsoLoad("maxStalled")
      * @ODM\Field(type="int", nullable=true)
      */
     protected $maxStalls;
@@ -133,13 +133,13 @@ abstract class BaseJob extends StallableJob
     protected $maxFailures;
 
     /**
-     * @ODM\AlsoLoad(name="errorCount")
+     * @ODM\AlsoLoad("errorCount")
      * @ODM\Field(type="int")
      */
     protected $exceptions = 0;
 
     /**
-     * @ODM\AlsoLoad(name="maxError")
+     * @ODM\AlsoLoad("maxError")
      * @ODM\Field(type="int", nullable=true)
      */
     protected $maxExceptions;


### PR DESCRIPTION
The use of the @AlsoLoad annotation in this bundle is wrong. Instead of 

```
     * @ODM\AlsoLoad(name="when")
```

we should be doing

```
     * @ODM\AlsoLoad("when")
```

(see the Doctrine documentation here: https://www.doctrine-project.org/projects/doctrine-mongodb-odm/en/2.3/reference/annotations-reference.html#alsoload )

The Doctrine annotations reader somehow accepted the wrong syntax but the latest version of the reader has stopped accepting it and this causes errors

This PR just fixes the code to use the right syntax

