### PR TITLE
Add support for Symfony 6

### DIFF
--- a/Command/CountCommand.php
+++ b/Command/CountCommand.php
@@ -24,7 +24,7 @@ class CountCommand extends Command
             ->setDescription('Display job queue status.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $waitingCount = $this->jobManager->getWaitingJobCount();
         $status = $this->jobManager->getStatus();
@@ -46,7 +46,7 @@ class CountCommand extends Command
         }
         $output->writeln("Total waiting jobs: {$waitingCount}");
 
-        return 0;
+        return $this::SUCCESS;
     }
 
     /**

--- a/Command/CreateJobCommand.php
+++ b/Command/CreateJobCommand.php
@@ -93,7 +93,7 @@ class CreateJobCommand extends Command
         $this->workerManager = $workerManager;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $workerName = $input->getArgument('worker_name');
         $methodName = $input->getArgument('method');
@@ -118,7 +118,7 @@ class CreateJobCommand extends Command
 
         $worker->getJobManager()->save($job);
 
-        return 0;
+        return $this::FAILURE;
     }
 
     protected function getArgs(InputInterface $input)

--- a/Command/CreateJobCommand.php
+++ b/Command/CreateJobCommand.php
@@ -117,7 +117,7 @@ class CreateJobCommand extends Command
 
         $worker->getJobManager()->save($job);
 
-        return $this::FAILURE;
+        return $this::SUCCESS;
     }
 
     protected function getArgs(InputInterface $input)

--- a/Command/CreateJobCommand.php
+++ b/Command/CreateJobCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateJobCommand extends Command
 {
-    protected static $defaultName = 'dtc:queue:create_job';
 
     /** @var WorkerManager */
     private $workerManager;
@@ -21,6 +20,7 @@ class CreateJobCommand extends Command
     protected function configure()
     {
         $this
+            ->setName("dtc:queue:create_job")
             ->addOption(
                 'json-args',
                 'j',
@@ -58,7 +58,6 @@ class CreateJobCommand extends Command
             )
             ->setDescription('Create a job - for expert users')
             ->setHelp($this->getHelpMessage())
-            ->setName(self::$defaultName)
         ;
     }
 

--- a/Command/PruneCommand.php
+++ b/Command/PruneCommand.php
@@ -190,13 +190,13 @@ class PruneCommand extends Command
     {
         switch ($modifier) {
             case 'd':
-                $interval = new \DateInterval("P${duration}D");
+                $interval = new \DateInterval("P{$duration}D");
                 break;
             case 'm':
-                $interval = new \DateInterval("P${duration}M");
+                $interval = new \DateInterval("P{$duration}M");
                 break;
             case 'y':
-                $interval = new \DateInterval("P${duration}Y");
+                $interval = new \DateInterval("P{$duration}Y");
                 break;
             default:
                 $interval = $this->getIntervalTime($modifier, $duration);
@@ -217,14 +217,14 @@ class PruneCommand extends Command
     {
         switch ($modifier) {
             case 'h':
-                $interval = new \DateInterval("PT${duration}H");
+                $interval = new \DateInterval("PT{$duration}H");
                 break;
             case 'i':
                 $seconds = $duration * 60;
-                $interval = new \DateInterval("PT${seconds}S");
+                $interval = new \DateInterval("PT{$seconds}S");
                 break;
             case 's':
-                $interval = new \DateInterval("PT${duration}S");
+                $interval = new \DateInterval("PT{$duration}S");
                 break;
             default:
                 throw new UnsupportedException("Unknown duration modifier: $modifier");

--- a/Command/PruneCommand.php
+++ b/Command/PruneCommand.php
@@ -50,7 +50,7 @@ class PruneCommand extends Command
         $this->jobTimingManager = $jobTimingManager;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $type = $input->getArgument('type');
         switch ($type) {
@@ -69,7 +69,7 @@ class PruneCommand extends Command
                 return $this->executeStalledOther($input, $output);
         }
 
-        return 0;
+        return $this::SUCCESS;
     }
 
     protected function pruneExceptionJobs(OutputInterface $output)

--- a/Command/ResetCommand.php
+++ b/Command/ResetCommand.php
@@ -24,13 +24,13 @@ class ResetCommand extends Command
         $this->jobManager = $jobManager;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $countException = $this->jobManager->resetExceptionJobs();
         $countStalled = $this->jobManager->resetStalledJobs();
         $output->writeln("$countException job(s) in status 'exception' reset");
         $output->writeln("$countStalled job(s) stalled (in status 'running') reset");
 
-        return 0;
+        return $this::SUCCESS;
     }
 }

--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -117,7 +117,7 @@ class RunCommand extends Command
         $this->container = $container;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $start = microtime(true);
         // @TODO: move this to dependency injection.
@@ -144,10 +144,12 @@ class RunCommand extends Command
         set_time_limit($processTimeout); // Set timeout on the process
 
         if ($jobId = $input->getOption('id')) {
-            return $this->runLoop->runJobById($start, $jobId); // Run a single job
+            $this->runLoop->runJobById($start, $jobId); // Run a single job
+            return $this::SUCCESS;
         }
 
-        return $this->runLoop->runLoop($start, $workerName, $methodName, $maxCount, $duration, $nanoSleep);
+        $this->runLoop->runLoop($start, $workerName, $methodName, $maxCount, $duration, $nanoSleep);
+        return $this::SUCCESS;
     }
 
     /**

--- a/DependencyInjection/DtcQueueExtension.php
+++ b/DependencyInjection/DtcQueueExtension.php
@@ -183,7 +183,7 @@ class DtcQueueExtension extends Extension
         }
     }
 
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'dtc_queue';
     }

--- a/Doctrine/DoctrineJobTimingManager.php
+++ b/Doctrine/DoctrineJobTimingManager.php
@@ -45,6 +45,6 @@ abstract class DoctrineJobTimingManager extends JobTimingManager
 
     public function pruneJobTimings(\DateTime $olderThan)
     {
-        return $this->removeOlderThan($this->getJobTimingClass(), 'createdAt', $olderThan);
+        return $this->removeOlderThan($this->getJobTimingClass(), 'finishedAt', $olderThan);
     }
 }

--- a/Run/Loop.php
+++ b/Run/Loop.php
@@ -198,7 +198,7 @@ class Loop
     {
         $endTime = null;
         if (null !== $duration) {
-            $interval = new \DateInterval("PT${duration}S");
+            $interval = new \DateInterval("PT{$duration}S");
             $endTime = clone $run->getStartedAt();
             $endTime->add($interval);
         }

--- a/Run/Loop.php
+++ b/Run/Loop.php
@@ -84,7 +84,7 @@ class Loop
     /**
      * @param float $start
      */
-    public function runJobById($start, $jobId)
+    public function runJobById($start, $jobId): void
     {
         $run = $this->runManager->runStart($start, null, null, $this->processTimeout);
         $this->lastRun = $run;
@@ -99,7 +99,7 @@ class Loop
             $this->log('error', "Job id is not found: {$jobId}");
             $this->runManager->runStop($run, $start);
 
-            return 0;
+            return;
         }
 
         $job = $this->workerManager->runJob($job);
@@ -107,8 +107,6 @@ class Loop
         $run->setProcessed(1);
         $this->runManager->runStop($run, $start);
         $this->log('info', 'Ended with 1 job processed over '.strval($run->getElapsed()).' seconds.');
-
-        return 0;
     }
 
     /**

--- a/Tests/Command/CommandTrait.php
+++ b/Tests/Command/CommandTrait.php
@@ -99,7 +99,7 @@ trait CommandTrait
         $container->set('dtc_queue.manager.run', $runManager);
         $container->set('dtc_queue.manager.job_timing', $jobTimingManager);
         $this->runCommandExpect($className, $container, $params, $expectedResult);
-        $manager = "${managerType}Manager";
+        $manager = "{$managerType}Manager";
         if (0 === $expectedResult) {
             self::assertTrue(isset($$manager->calls[$call][0]));
             self::assertTrue(!isset($$manager->calls[$call][1]));

--- a/Util/Util.php
+++ b/Util/Util.php
@@ -153,9 +153,9 @@ class Util
         $timePart = substr($decimal, 0, $len);
         $decimalPart = substr($decimal, $len, 6);
 
-        $result = \DateTime::createFromFormat('U.u', "${timePart}.${decimalPart}");
+        $result = \DateTime::createFromFormat('U.u', "{$timePart}.{$decimalPart}");
         if (!$result) {
-            throw new \RuntimeException("Could not create date time from ${timePart}.${decimalPart}");
+            throw new \RuntimeException("Could not create date time from {$timePart}.{$decimalPart}");
         }
         $result->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "symfony/framework-bundle": ">=2.7|>=3.3|4.*|5.*",
-        "sensio/framework-extra-bundle": "2.*|3.*|4.*|5.*|6.*",
+        "symfony/framework-bundle": ">=2.7|>=3.3|4.*|5.*|6.*",
         "cocur/background-process": ">=0.7"
     },
     "require-dev": {
@@ -46,7 +45,7 @@
 	"scrutinizer/ocular": "dev-master"
     },
     "suggest": {
-        "mmucklo/grid-bundle": ">=7.2.1",
+        "mmucklo/grid-bundle": ">=8.0.0",
         "snc/redis-bundle": "If using redis",
         "predis/predis": "If using redis",
         "ext-redis": "Alternative redis library",
@@ -57,6 +56,9 @@
         "oro/doctrine-extensions": "For YEAR, MONTH, DAY, HOUR, MINUTE date functions if using JobTiming trends",
         "beberlei/DoctrineExtensions": "Alternative for YEAR, MONTH, DAY, HOUR, MINUTE if using JobTiming trends",
         "alcaeus/mongo-php-adapter": "If trying to use MongoDB ODM on PHP 7.0 or greater"
+    },
+    "conflict": {
+        "mmucklo/grid-bundle": "<8.0.0"
     },
     "config": {
         "bin-dir": "bin",

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": ">=7.1",
         "symfony/framework-bundle": ">=2.7|>=3.3|4.*|5.*|6.*",
+        "sensio/framework-extra-bundle": "2.*|3.*|4.*|5.*|6.*",
         "cocur/background-process": ">=0.7"
     },
     "require-dev": {


### PR DESCRIPTION
I've added rudimentary support for Symfony 6, fixed some deprecations, and squashed a bug.

- Changed all usages of the php deprecated ${var} notation in strings to instead use {$var}
- Fix for pruning old-job-timings- the DoctrineJobTimingManager now uses the finishedAt property rather than the undefined createdAt one.
- Added int return types to the execute method within all Commands; refactored the return 0 to return $this::SUCCESS
- Removed the overriding of command's $defaultName and replaced it with $this->setName() in the configure method
- Modified dependencies to restrict Grid bundle installation to the next unreleased major version of the grid bundle.

This does not support any currently released version of DtcGridbundle- The grid bundle will need to be upgraded separately if its wanting to be used alongside the queue bundle. I had the initial intention of knocking them both out at once but the grid bundle is seemingly plagued with fetching twig from the container which is no longer possible due to the twig service being marked as private as of symfony/twig-bridge >=6. That being said, we'll need to rework the bundle to use DI to fetch the twig service and that seems like a larger undertaking than I can commit to at this time.