### PR TITLE
Removed doctrine/orm 3 from require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "cocur/background-process": ">=0.7"
     },
     "require-dev": {
-        "doctrine/orm": "^2.7|^3.0",
+        "doctrine/orm": "^2.7",
         "doctrine/annotations": "^1.5",
         "doctrine/cache": "^1.7",
         "doctrine/collections": "^1.5",


### PR DESCRIPTION
With the official release of doctrine/orm 3, I figured it'd make the most sense to limit the package requirements to exclude version 3 until the package actually works alongside it. A few of the changes necessary to make that happen include migrating to php attributes (requires PHP 8!), using the specific lifeCycleEventArgs classes, and many more changes outlined [here](https://github.com/doctrine/orm/blob/3.0.x/UPGRADE.md)

The above req's would likely mean that Orm 3 support will be pushed off for a later major release alongside Symfony 7 and PHP 8.1.