### PR TITLE
Symfony 7 support

### DIFF
--- a/Command/CountCommand.php
+++ b/Command/CountCommand.php
@@ -17,7 +17,7 @@ class CountCommand extends Command
         $this->jobManager = $jobManager;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('dtc:queue:count')

--- a/Command/CreateJobCommand.php
+++ b/Command/CreateJobCommand.php
@@ -17,7 +17,7 @@ class CreateJobCommand extends Command
     /** @var WorkerManager */
     private $workerManager;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName("dtc:queue:create_job")

--- a/Command/PruneCommand.php
+++ b/Command/PruneCommand.php
@@ -26,7 +26,7 @@ class PruneCommand extends Command
     /** @var JobTimingManager */
     private $jobTimingManager;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
         ->setName('dtc:queue:prune')

--- a/Command/ResetCommand.php
+++ b/Command/ResetCommand.php
@@ -12,7 +12,7 @@ class ResetCommand extends Command
     /** @var JobManagerInterface */
     private $jobManager;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('dtc:queue:reset')

--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -39,7 +39,7 @@ class RunCommand extends Command
         }
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->symfonyDetect();
         $options = [

--- a/DependencyInjection/Compiler/BeanstalkdCompilerPass.php
+++ b/DependencyInjection/Compiler/BeanstalkdCompilerPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class BeanstalkdCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasParameter('dtc_queue.beanstalkd.host') &&
             $container->getParameter('dtc_queue.beanstalkd.host')) {

--- a/DependencyInjection/Compiler/GridCompilerPass.php
+++ b/DependencyInjection/Compiler/GridCompilerPass.php
@@ -9,7 +9,7 @@ class GridCompilerPass implements CompilerPassInterface
 {
     use WorkerCompilerTrait;
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!class_exists('Dtc\GridBundle\DtcGridBundle')) {
             $container->getDefinition('dtc_queue.grid_source.jobs_waiting.odm')->setClass('Dtc\QueueBundle\ODM\StubLiveJobsGridSource');

--- a/DependencyInjection/Compiler/RabbitMQCompilerPass.php
+++ b/DependencyInjection/Compiler/RabbitMQCompilerPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class RabbitMQCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasParameter('dtc_queue.rabbit_mq') &&
             $container->getParameter('dtc_queue.rabbit_mq')) {

--- a/DependencyInjection/Compiler/RedisCompilerPass.php
+++ b/DependencyInjection/Compiler/RedisCompilerPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class RedisCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasParameter('dtc_queue.redis.snc_redis.type') &&
             $container->getParameter('dtc_queue.redis.snc_redis.type')) {

--- a/DependencyInjection/Compiler/WorkerCompilerPass.php
+++ b/DependencyInjection/Compiler/WorkerCompilerPass.php
@@ -18,7 +18,7 @@ class WorkerCompilerPass implements CompilerPassInterface
 {
     use WorkerCompilerTrait;
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('dtc_queue.manager.worker')) {
             return;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
      *
      * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('dtc_queue');
 

--- a/DependencyInjection/DtcQueueExtension.php
+++ b/DependencyInjection/DtcQueueExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class DtcQueueExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $processor = new Processor();
         $configuration = new Configuration();

--- a/Document/BaseJob.php
+++ b/Document/BaseJob.php
@@ -7,150 +7,98 @@ use Dtc\QueueBundle\Model\StallableJob;
 
 abstract class BaseJob extends StallableJob
 {
-    /**
-     * @ODM\Id
-     */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string", name="worker_name")
-     */
+    #[ODM\Field(type: 'string', name: 'worker_name')]
     protected $workerName;
 
-    /**
-     * @ODM\Field(type="string", name="class_name")
-     */
+    #[ODM\Field(type: 'string', name: 'class_name')]
     protected $className;
 
-    /**
-     * @ODM\Field(type="string")
-     */
+    #[ODM\Field(type: 'string')]
     protected $method;
 
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\Index(unique=false, order="asc")
-     */
+    #[ODM\Field(type: 'string')]
+    #[ODM\Index(unique: false, order: 'asc')]
     protected $status;
 
-    /**
-     * @ODM\Field(type="hash")
-     */
+    #[ODM\Field(type: 'hash')]
     protected $args;
 
-    /**
-     * @ODM\Field(type="boolean", nullable=true)
-     */
+    #[ODM\Field(type: 'boolean', nullable: true)]
     protected $batch;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     * @ODM\Index(unique=false, order="asc")
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
+    #[ODM\Index(unique: false, order: 'asc')]
     protected $priority;
 
-    /**
-     * @ODM\Field(type="string")
-     */
+    #[ODM\Field(type: 'string')]
     protected $crcHash;
 
-    /**
-     * @ODM\Field(type="date", nullable=true)
-     * @ODM\AlsoLoad("when")
-     * @ODM\Index(unique=false, order="asc")
-     */
+    #[ODM\Field(type: 'date', nullable: true)]
+    #[ODM\AlsoLoad('when')]
+    #[ODM\Index(unique: false, order: 'asc')]
     protected $whenAt;
 
-    /**
-     * @ODM\Field(type="date", nullable=true)
-     */
+    #[ODM\Field(type: 'date', nullable: true)]
     protected $expiresAt;
 
     /**
      * When the job started.
-     *
-     * @ODM\Field(type="date", nullable=true)
      */
+    #[ODM\Field(type: 'date', nullable: true)]
     protected $startedAt;
 
     /**
      * When the job finished.
-     *
-     * @ODM\Field(type="date", nullable=true)
      */
+    #[ODM\Field(type: 'date', nullable: true)]
     protected $finishedAt;
 
-    /**
-     * @ODM\Field(type="float", nullable=true)
-     */
+    #[ODM\Field(type: 'float', nullable: true)]
     protected $elapsed;
 
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     */
+    #[ODM\Field(type: 'string', nullable: true)]
     protected $message;
 
-    /**
-     * @ODM\Field(type="date")
-     */
+    #[ODM\Field(type: 'date')]
     protected $createdAt;
 
-    /**
-     * @ODM\Field(type="date")
-     */
+    #[ODM\Field(type: 'date')]
     protected $updatedAt;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $maxDuration;
 
-    /**
-     * @ODM\Field(type="object_id", nullable=true)
-     */
+    #[ODM\Field(type: 'object_id', nullable: true)]
     protected $runId;
 
-    /**
-     * @ODM\AlsoLoad("stalledCount")
-     * @ODM\Field(type="int")
-     */
+    #[ODM\AlsoLoad('stalledCount')]
+    #[ODM\Field(type: 'int')]
     protected $stalls = 0;
 
-    /**
-     * @ODM\AlsoLoad("maxStalled")
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\AlsoLoad('maxStalled')]
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $maxStalls;
 
-    /**
-     * @ODM\Field(type="int")
-     */
+    #[ODM\Field(type: 'int')]
     protected $failures = 0;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $maxFailures;
 
-    /**
-     * @ODM\AlsoLoad("errorCount")
-     * @ODM\Field(type="int")
-     */
+    #[ODM\AlsoLoad('errorCount')]
+    #[ODM\Field(type: 'int')]
     protected $exceptions = 0;
 
-    /**
-     * @ODM\AlsoLoad("maxError")
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\AlsoLoad('maxError')]
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $maxExceptions;
 
-    /**
-     * @ODM\Field(type="int")
-     */
+    #[ODM\Field(type: 'int')]
     protected $retries = 0;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $maxRetries;
 }

--- a/Document/BaseRun.php
+++ b/Document/BaseRun.php
@@ -6,62 +6,36 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 abstract class BaseRun extends \Dtc\QueueBundle\Model\Run
 {
-    /**
-     * @ODM\Id
-     */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="date", nullable=true)
-     */
+    #[ODM\Field(type: 'date', nullable: true)]
     protected $startedAt;
 
-    /**
-     * @ODM\Field(type="date", nullable=true)
-     */
+    #[ODM\Field(type: 'date', nullable: true)]
     protected $endedAt;
 
-    /**
-     * @ODM\Field(type="float", nullable=true)
-     */
+    #[ODM\Field(type: 'float', nullable: true)]
     protected $elapsed;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $duration; // How long to run for in seconds
-
-    /**
-     * @ODM\Field(type="date")
-     */
+    #[ODM\Field(type: 'date')]
     protected $lastHeartbeatAt;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $maxCount;
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $processed; // Number of jobs processed
-
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     */
+    #[ODM\Field(type: 'string', nullable: true)]
     protected $hostname;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $pid;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $processTimeout;
 
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     */
+    #[ODM\Field(type: 'string', nullable: true)]
     protected $currentJobId;
 }

--- a/Document/Job.php
+++ b/Document/Job.php
@@ -4,9 +4,7 @@ namespace Dtc\QueueBundle\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(db="dtc_queue", collection="job")
- */
+#[ODM\Document(db: 'dtc_queue', collection: 'job')]
 class Job extends BaseJob
 {
     public const STATUS_ARCHIVE = 'archive';

--- a/Document/JobArchive.php
+++ b/Document/JobArchive.php
@@ -4,49 +4,35 @@ namespace Dtc\QueueBundle\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(db="dtc_queue", collection="job_archive")
- */
+#[ODM\Document(db: 'dtc_queue', collection: 'job_archive')]
 class JobArchive extends BaseJob
 {
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $priority;
 
-    /**
-     * @ODM\Field(type="date", nullable=true)
-     */
+    #[ODM\Field(type: 'date', nullable: true)]
     protected $whenAt;
 
     /**
      * When the job finished.
-     *
-     * @ODM\Field(type="date", nullable=true)
-     * @ODM\Index(unique=false, order="desc")
      */
+    #[ODM\Field(type: 'date', nullable: true)]
+    #[ODM\Index(unique: false, order: 'desc')]
     protected $finishedAt;
 
-    /**
-     * @ODM\Field(type="float")
-     */
+    #[ODM\Field(type: 'float')]
     protected $elapsed;
 
     /**
      * When the job finished.
-     *
-     * @ODM\Field(type="date", nullable=true)
      */
+    #[ODM\Field(type: 'date', nullable: true)]
     protected $startedAt;
 
-    /**
-     * @ODM\Field(type="date", nullable=true)
-     */
+    #[ODM\Field(type: 'date', nullable: true)]
     protected $expiresAt;
 
-    /**
-     * @ODM\Field(type="date")
-     * @ODM\Index(unique=false)
-     */
+    #[ODM\Field(type: 'date')]
+    #[ODM\Index(unique: false)]
     protected $updatedAt;
 }

--- a/Document/JobTiming.php
+++ b/Document/JobTiming.php
@@ -5,14 +5,10 @@ namespace Dtc\QueueBundle\Document;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Dtc\QueueBundle\Model\JobTiming as BaseJobTiming;
 
-/**
- * @ODM\Document(db="dtc_queue", collection="job_timing")
- */
+#[ODM\Document(db: 'dtc_queue', collection: 'job_timing')]
 class JobTiming extends BaseJobTiming
 {
-    /**
-     * @ODM\Id
-     */
+    #[ODM\Id]
     protected $id;
 
     /**
@@ -31,15 +27,11 @@ class JobTiming extends BaseJobTiming
         $this->id = $id;
     }
 
-    /**
-     * @ODM\Field(type="date")
-     * @ODM\Index(unique=false, order="asc")
-     */
+    #[ODM\Field(type: 'date')]
+    #[ODM\Index(unique: false, order: 'asc')]
     protected $finishedAt;
 
-    /**
-     * @ODM\Field(type="integer")
-     * @ODM\Index(unique=false, order="asc")
-     */
+    #[ODM\Field(type: 'integer')]
+    #[ODM\Index(unique: false, order: 'asc')]
     protected $status;
 }

--- a/Document/Run.php
+++ b/Document/Run.php
@@ -4,9 +4,7 @@ namespace Dtc\QueueBundle\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(db="dtc_queue", collection="run")
- */
+#[ODM\Document(db: 'dtc_queue', collection: 'run')]
 class Run extends BaseRun
 {
 }

--- a/Document/RunArchive.php
+++ b/Document/RunArchive.php
@@ -4,48 +4,29 @@ namespace Dtc\QueueBundle\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(db="dtc_queue", collection="run_archive")
- */
+#[ODM\Document(db: 'dtc_queue', collection: 'run_archive')]
 class RunArchive extends BaseRun
 {
-    /**
-     * @ODM\Field(type="date", nullable=true)
-     */
+    #[ODM\Field(type: 'date', nullable: true)]
     protected $startedAt;
-    /**
-     * @ODM\Field(type="date", nullable=true)
-     * @ODM\Index(unique=false, order="desc")
-     */
+    #[ODM\Field(type: 'date', nullable: true)]
+    #[ODM\Index(unique: false, order: 'desc')]
     protected $endedAt;
 
-    /**
-     * @ODM\Field(type="float", nullable=true)
-     */
+    #[ODM\Field(type: 'float', nullable: true)]
     protected $elapsed;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $duration; // How long to run for in seconds
-
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $maxCount;
 
-    /**
-     * @ODM\Field(type="date")
-     */
+    #[ODM\Field(type: 'date')]
     protected $lastHeartbeatAt;
 
-    /**
-     * @ODM\Field(type="int", nullable=true)
-     */
+    #[ODM\Field(type: 'int', nullable: true)]
     protected $processTimeout;
 
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     */
+    #[ODM\Field(type: 'string', nullable: true)]
     protected $currentJobId;
 }

--- a/DtcQueueBundle.php
+++ b/DtcQueueBundle.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class DtcQueueBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
         $container->addCompilerPass(new WorkerCompilerPass());

--- a/Entity/BaseJob.php
+++ b/Entity/BaseJob.php
@@ -12,142 +12,93 @@ use Dtc\QueueBundle\Model\StallableJob;
 abstract class BaseJob extends StallableJob
 {
     use MicrotimeTrait;
-    /**
-     * @ORM\Column(name="id", type="bigint")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Column(name: 'id', type: 'bigint')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\Column(name="worker_name", type="string")
-     */
+    #[ORM\Column(name: 'worker_name', type: 'string')]
     protected $workerName;
 
-    /**
-     * @ORM\Column(name="class_name", type="string")
-     */
+    #[ORM\Column(name: 'class_name', type: 'string')]
     protected $className;
 
-    /**
-     * @ORM\Column(name="method", type="string")
-     */
+    #[ORM\Column(name: 'method', type: 'string')]
     protected $method;
 
-    /**
-     * @ORM\Column(name="status", type="string")
-     */
+    #[ORM\Column(name: 'status', type: 'string')]
     protected $status;
 
-    /**
-     * @ORM\Column(name="args", type="text")
-     */
+    #[ORM\Column(name: 'args', type: 'text')]
     protected $args;
 
-    /**
-     * @ORM\Column(name="priority", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'priority', type: 'integer', nullable: true)]
     protected $priority;
 
-    /**
-     * @ORM\Column(name="crc_hash", type="string")
-     */
+    #[ORM\Column(name: 'crc_hash', type: 'string')]
     protected $crcHash;
 
     /**
      * whenAt in Microseconds.
-     *
-     * @ORM\Column(name="when_us", type="decimal", precision=18, scale=0, nullable=true)
      */
+    #[ORM\Column(name: 'when_us', type: 'decimal', precision: 18, scale: 0, nullable: true)]
     protected $whenUs;
 
-    /**
-     * @ORM\Column(name="expires_at", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'expires_at', type: 'datetime', nullable: true)]
     protected $expiresAt;
 
     /**
      * When the job started.
-     *
-     * @ORM\Column(name="started_at", type="datetime", nullable=true)
      */
+    #[ORM\Column(name: 'started_at', type: 'datetime', nullable: true)]
     protected $startedAt;
 
     /**
      * When the job finished.
-     *
-     * @ORM\Column(name="finished_at", type="datetime", nullable=true)
      */
+    #[ORM\Column(name: 'finished_at', type: 'datetime', nullable: true)]
     protected $finishedAt;
 
-    /**
-     * @ORM\Column(name="elapsed", type="float", nullable=true)
-     */
+    #[ORM\Column(name: 'elapsed', type: 'float', nullable: true)]
     protected $elapsed;
 
-    /**
-     * @ORM\Column(name="message", type="text", nullable=true)
-     */
+    #[ORM\Column(name: 'message', type: 'text', nullable: true)]
     protected $message;
 
-    /**
-     * @ORM\Column(name="created_at", type="datetime")
-     */
+    #[ORM\Column(name: 'created_at', type: 'datetime')]
     protected $createdAt;
 
-    /**
-     * @ORM\Column(name="updated_at", type="datetime")
-     */
+    #[ORM\Column(name: 'updated_at', type: 'datetime')]
     protected $updatedAt;
 
-    /**
-     * @ORM\Column(name="max_duration", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'max_duration', type: 'integer', nullable: true)]
     protected $maxDuration;
 
-    /**
-     * @ORM\Column(name="run_id", type="bigint", nullable=true)
-     */
+    #[ORM\Column(name: 'run_id', type: 'bigint', nullable: true)]
     protected $runId;
 
-    /**
-     * @ORM\Column(name="stalls", type="integer")
-     */
+    #[ORM\Column(name: 'stalls', type: 'integer')]
     protected $stalls = 0;
 
-    /**
-     * @ORM\Column(name="max_stalls", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'max_stalls', type: 'integer', nullable: true)]
     protected $maxStalls;
 
-    /**
-     * @ORM\Column(name="exceptions", type="integer")
-     */
+    #[ORM\Column(name: 'exceptions', type: 'integer')]
     protected $exceptions = 0;
 
-    /**
-     * @ORM\Column(name="max_exceptions", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'max_exceptions', type: 'integer', nullable: true)]
     protected $maxExceptions;
 
-    /**
-     * @ORM\Column(name="failures", type="integer")
-     */
+    #[ORM\Column(name: 'failures', type: 'integer')]
     protected $failures = 0;
 
-    /**
-     * @ORM\Column(name="max_failures", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'max_failures', type: 'integer', nullable: true)]
     protected $maxFailures;
 
-    /**
-     * @ORM\Column(name="retries", type="integer")
-     */
+    #[ORM\Column(name: 'retries', type: 'integer')]
     protected $retries = 0;
 
-    /**
-     * @ORM\Column(name="max_retries", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'max_retries', type: 'integer', nullable: true)]
     protected $maxRetries;
 
     /**

--- a/Entity/BaseRun.php
+++ b/Entity/BaseRun.php
@@ -9,61 +9,35 @@ use Doctrine\ORM\Mapping as ORM;
  */
 abstract class BaseRun extends \Dtc\QueueBundle\Model\Run
 {
-    /**
-     * @ORM\Column(name="id", type="bigint")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Column(name: 'id', type: 'bigint')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
-    /**
-     * @ORM\Column(name="started_at", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'started_at', type: 'datetime', nullable: true)]
     protected $startedAt;
-    /**
-     * @ORM\Column(name="ended_at", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'ended_at', type: 'datetime', nullable: true)]
     protected $endedAt;
 
-    /**
-     * @ORM\Column(name="elapsed", type="float", nullable=true)
-     */
+    #[ORM\Column(name: 'elapsed', type: 'float', nullable: true)]
     protected $elapsed;
 
-    /**
-     * @ORM\Column(name="duration", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'duration', type: 'integer', nullable: true)]
     protected $duration; // How long to run for in seconds
-
-    /**
-     * @ORM\Column(name="last_heartbeat_at", type="datetime")
-     */
+    #[ORM\Column(name: 'last_heartbeat_at', type: 'datetime')]
     protected $lastHeartbeatAt;
 
-    /**
-     * @ORM\Column(name="max_count", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'max_count', type: 'integer', nullable: true)]
     protected $maxCount;
-    /**
-     * @ORM\Column(name="processed", type="integer")
-     */
+    #[ORM\Column(name: 'processed', type: 'integer')]
     protected $processed = 0; // Number of jobs processed
-
-    /**
-     * @ORM\Column(name="hostname", type="string", nullable=true)
-     */
+    #[ORM\Column(name: 'hostname', type: 'string', nullable: true)]
     protected $hostname;
-    /**
-     * @ORM\Column(name="pid", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'pid', type: 'integer', nullable: true)]
     protected $pid;
 
-    /**
-     * @ORM\Column(name="process_timeout", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'process_timeout', type: 'integer', nullable: true)]
     protected $processTimeout;
 
-    /**
-     * @ORM\Column(name="current_job_id", type="string", nullable=true)
-     */
+    #[ORM\Column(name: 'current_job_id', type: 'string', nullable: true)]
     protected $currentJobId;
 }

--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -7,20 +7,18 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * Note: the number of indexes was purposefully kept smaller than it could be (such as adding an expires index)
  *   This was done to keep the number of indexes reasonably minimal for insert performance considerations.
- *
- * @ORM\Entity
- * @ORM\Table(name="dtc_queue_job", indexes={@ORM\Index(name="job_crc_hash_idx", columns={"crc_hash","status"}),
- *                  @ORM\Index(name="job_priority_idx", columns={"priority","when_us"}),
- *                  @ORM\Index(name="job_when_idx", columns={"when_us"}),
- *                  @ORM\Index(name="job_status_idx", columns={"status","when_us"})})
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'dtc_queue_job')]
+#[ORM\Index(columns: ['crc_hash', 'status'], name: 'job_crc_hash_idx')]
+#[ORM\Index(columns: ['priority', 'when_us'], name: 'job_priority_idx')]
+#[ORM\Index(columns: ['when_us'], name: 'job_when_idx')]
+#[ORM\Index(columns: ['status', 'when_us'], name: 'job_status_idx')]
 class Job extends BaseJob
 {
     public const STATUS_ARCHIVE = 'archive';
-    /**
-     * @ORM\Column(name="id", type="bigint")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Column(name: 'id', type: 'bigint')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 }

--- a/Entity/JobArchive.php
+++ b/Entity/JobArchive.php
@@ -4,56 +4,40 @@ namespace Dtc\QueueBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="dtc_queue_job_archive",indexes={
- *                  @ORM\Index(name="job_archive_status_idx", columns={"status"}),
- *                  @ORM\Index(name="job_archive_updated_at_idx", columns={"updated_at"})})
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'dtc_queue_job_archive')]
+#[ORM\Index(columns: ['status'], name: 'job_archive_status_idx')]
+#[ORM\Index(columns: ['updated_at'], name: 'job_archive_updated_at_idx')]
 class JobArchive extends BaseJob
 {
-    /**
-     * @ORM\Column(name="id", type="bigint")
-     * @ORM\Id
-     */
+    #[ORM\Column(name: 'id', type: 'bigint')]
+    #[ORM\Id]
     protected $id;
 
     /**
      * When the job finished.
-     *
-     * @ORM\Column(name="finished_at", type="datetime", nullable=true)
      */
+    #[ORM\Column(name: 'finished_at', type: 'datetime', nullable: true)]
     protected $finishedAt;
 
-    /**
-     * @ORM\Column(name="elapsed", type="float", nullable=true)
-     */
+    #[ORM\Column(name: 'elapsed', type: 'float', nullable: true)]
     protected $elapsed;
 
     /**
      * When the job started.
-     *
-     * @ORM\Column(name="started_at", type="datetime", nullable=true)
      */
+    #[ORM\Column(name: 'started_at', type: 'datetime', nullable: true)]
     protected $startedAt;
 
-    /**
-     * @ORM\Column(name="when_us", type="decimal", precision=18, scale=0, nullable=true)
-     */
+    #[ORM\Column(name: 'when_us', type: 'decimal', precision: 18, scale: 0, nullable: true)]
     protected $whenUs;
 
-    /**
-     * @ORM\Column(name="priority", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'priority', type: 'integer', nullable: true)]
     protected $priority;
 
-    /**
-     * @ORM\Column(name="expires_at", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'expires_at', type: 'datetime', nullable: true)]
     protected $expiresAt;
 
-    /**
-     * @ORM\Column(name="updated_at", type="datetime")
-     */
+    #[ORM\Column(name: 'updated_at', type: 'datetime')]
     protected $updatedAt;
 }

--- a/Entity/JobTiming.php
+++ b/Entity/JobTiming.php
@@ -5,27 +5,20 @@ namespace Dtc\QueueBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Dtc\QueueBundle\Model\JobTiming as BaseJobTiming;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="dtc_queue_job_timing", indexes={@ORM\Index(name="job_timing_finished_at", columns={"status", "finished_at"})})
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'dtc_queue_job_timing')]
+#[ORM\Index(columns: ['status', 'finished_at'], name: 'job_timing_finished_at')]
 class JobTiming extends BaseJobTiming
 {
-    /**
-     * @ORM\Column(name="id", type="bigint")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Column(name: 'id', type: 'bigint')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\Column(name="finished_at", type="datetime")
-     */
+    #[ORM\Column(name: 'finished_at', type: 'datetime')]
     protected $finishedAt;
 
-    /**
-     * @ORM\Column(name="status", type="integer")
-     */
+    #[ORM\Column(name: 'status', type: 'integer')]
     protected $status;
 
     /**

--- a/Entity/Run.php
+++ b/Entity/Run.php
@@ -4,10 +4,9 @@ namespace Dtc\QueueBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="dtc_queue_run", indexes={@ORM\Index(name="run_last_heart_beat", columns={"last_heartbeat_at"})})
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'dtc_queue_run')]
+#[ORM\Index(columns: ['last_heartbeat_at'], name: 'run_last_heart_beat')]
 class Run extends BaseRun
 {
 }

--- a/Entity/RunArchive.php
+++ b/Entity/RunArchive.php
@@ -4,50 +4,30 @@ namespace Dtc\QueueBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="dtc_queue_run_archive")
- * @ORM\Table(name="dtc_queue_run_archive",indexes={
- *                  @ORM\Index(name="run_archive_ended_at_idx", columns={"ended_at"})})
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'dtc_queue_run_archive')]
+#[ORM\Index(columns: ['ended_at'], name: 'run_archive_ended_at_idx')]
 class RunArchive extends BaseRun
 {
-    /**
-     * @ORM\Column(name="started_at", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'started_at', type: 'datetime', nullable: true)]
     protected $startedAt;
-    /**
-     * @ORM\Column(name="duration", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'duration', type: 'integer', nullable: true)]
     protected $duration; // How long to run for in seconds
-
-    /**
-     * @ORM\Column(name="ended_at", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'ended_at', type: 'datetime', nullable: true)]
     protected $endedAt;
 
-    /**
-     * @ORM\Column(name="elapsed", type="float", nullable=true)
-     */
+    #[ORM\Column(name: 'elapsed', type: 'float', nullable: true)]
     protected $elapsed;
 
-    /**
-     * @ORM\Column(name="max_count", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'max_count', type: 'integer', nullable: true)]
     protected $maxCount;
 
-    /**
-     * @ORM\Column(name="last_heartbeat_at", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'last_heartbeat_at', type: 'datetime', nullable: true)]
     protected $lastHeartbeatAt;
 
-    /**
-     * @ORM\Column(name="process_timeout", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'process_timeout', type: 'integer', nullable: true)]
     protected $processTimeout;
 
-    /**
-     * @ORM\Column(name="current_job_id", type="string", nullable=true)
-     */
+    #[ORM\Column(name: 'current_job_id', type: 'string', nullable: true)]
     protected $currentJobId;
 }

--- a/README.md
+++ b/README.md
@@ -498,13 +498,12 @@ namespace App\Entity; // Or whatever
 use Dtc\QueueBundle\Entity\Job as BaseJob;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="job_some_other_name", indexes={@ORM\Index(name="job_crc_hash_idx", columns={"crcHash","status"}),
- *                  @ORM\Index(name="job_priority_idx", columns={"priority","whenAt"}),
- *                  @ORM\Index(name="job_when_idx", columns={"whenAt"}),
- *                  @ORM\Index(name="job_status_idx", columns={"status","whenAt"})})
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'job_some_other_name')]
+#[ORM\Index(columns: ['crc_hash', 'status'], name: 'job_crc_hash_idx')]
+#[ORM\Index(columns: ['priority', 'whenAt'], name: 'job_priority_idx')]
+#[ORM\Index(columns: ['whenAt'], name: 'job_when_idx')]
+#[ORM\Index(columns: ['status', 'whenAt'], name: 'job_status_idx')]
 class Job extends BaseJob {
 }
 
@@ -518,9 +517,7 @@ namespace App\Document;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Dtc\QueueBundle\Document\Job as BaseJob;
 
-/**
- * @ODM\Document(db="my_db", collection="my_job_collection")
- */
+#[ODM\Document(db: 'my_db', collection: 'my_job_collection')]
 class Job extends BaseJob
 {
 }

--- a/Tests/Manager/BaseJobManagerTest.php
+++ b/Tests/Manager/BaseJobManagerTest.php
@@ -235,9 +235,6 @@ abstract class BaseJobManagerTest extends TestCase
         return self::fudgeRabbitMQCount($count, $expected);
     }
 
-    /**
-     * @outputBuffering disabled
-     */
     public function testPerformance()
     {
         echo "\n".static::class.": Testing Performance\n";

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.7",
-        "doctrine/annotations": "^1.5",
         "doctrine/cache": "^1.7",
         "doctrine/collections": "^1.5",
         "doctrine/instantiator": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,8 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "symfony/framework-bundle": ">=2.7|>=3.3|4.*|5.*|6.*",
-        "sensio/framework-extra-bundle": "2.*|3.*|4.*|5.*|6.*",
+        "php": ">=8.1",
+        "symfony/framework-bundle": "6.*|7.*",
         "cocur/background-process": ">=0.7"
     },
     "require-dev": {


### PR DESCRIPTION
Included in this are a few notable changes

- Migrated from Doctrine/annotations to native php attributes
- Removed dependency sensio/framework-extra-bundle (I couldn't find any usage anyhow)
- Added strong return types where necessary
- Changed supported versions of PHP to 8.1, Symfony to >=6

All of the annotation->attributes were performed with rector using Doctrine's changesets. I manually reviewed quite a bit where able but haven't had the luxury of testing everything.